### PR TITLE
allow from range_regex import regex_for_range as documented

### DIFF
--- a/range_regex/__init__.py
+++ b/range_regex/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'dimka'
 
-from .range_regex import range_to_pattern, bounded_regex_for_range
+from .range_regex import regex_for_range, bounded_regex_for_range


### PR DESCRIPTION
First of all, thanks for sharing this excellent module; very useful for generating regexes to be used in apache 2.2 config from a collection of ip address ranges.

It looks to me like range_to_pattern was intended for internal use only, so I just replaced it with range_for_regex to allow `from range_regex import regex_for_range` as specified in the project's readme. Please forgive if I've got this all wrong :anguished: 

Thanks again!
