### PR TITLE
Correct README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Usage
 -----
 ::
 
-    from range_regex import regex_for_range
+    from range_regex import bounded_regex_for_range
 
     regex_for_range(12, 34)
 


### PR DESCRIPTION
As depaoli pointed out, this should instruct users to call bounded_regex_for_range, not regex_for_range. That's all this pull request does. 